### PR TITLE
Updated php-cs-fixer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "squizlabs/php_codesniffer": "@stable",
-        "fabpot/php-cs-fixer": "@stable",
+        "friendsofphp/php-cs-fixer": "@stable",
         "symfony/console": "@stable",
         "symfony/process": "@stable"
     }


### PR DESCRIPTION
Package `fabpot/php-cs-fixer` has been marked as abandoned and the replacement is `friendsofphp/php-cs-fixer`.
